### PR TITLE
Added usernames to users

### DIFF
--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -11,13 +11,39 @@ const userController: Router = express.Router();
 
 userController.post('/register', async (req: Request, res: Response) => {
 	const body: RegisterRequestDTO = req.body;
+	if (body.username == undefined) {
+		console.log("[-] WalletRegistration: Missing username")
+		res.status(401).send({ err: "MISSING_USERNAME" });
+		return;
+	}
 	if (body.password == undefined) {
 		console.log("[-] WalletRegistration: Missing password")
 		res.status(401).send({ err: "MISSING_PASSWORD" });
 		return;
 	}
+	if (body.repeatpw == undefined) {
+		console.log("[-] WalletRegistration: Missing repeat password")
+		res.status(401).send({ err: "MISSING_REPEAT_PASSWORD" });
+		return;
+	}
+	if (body.password !== body.repeatpw) {
+		console.log("[-] WalletRegistration: Passwords do not match")
+		res.status(401).send({ err: "PASSWORDS_NOT_MATCHING" });
+		return;
+	}
+
+	const userExistsResult = await userService.checkIfUserExists(body.username);
+	if (!userExistsResult.ok) {
+		res.status(400).send({err: userExistsResult.val});
+		return;
+	}
+	if (userExistsResult.val) {
+		console.log("[-] WalletRegistration: Username already exists")
+		res.status(401).send({ err: "USERNAME_ALREADY_EXISTS" });
+		return;
+	}
 	
-	const registerUserResult = await userService.registerUser(body.password);
+	const registerUserResult = await userService.registerUser(body.username, body.password);
 	if (!registerUserResult.ok) {
 		res.status(400).send({err: registerUserResult.val});
 		return;
@@ -27,16 +53,29 @@ userController.post('/register', async (req: Request, res: Response) => {
 });
 
 userController.post('/login', async (req: Request, res: Response) => {
-
 	const body: LoginUserRequestDTO = req.body;
-	if (body.did == undefined || body.password == undefined) {
-		res.status(401).send({error: "DID or password is missing from body"});
+	if (body.username == undefined) {
+		console.log("[-] WalletLogin: Missing username");
+		res.status(401).send({ err: "MISSING_USERNAME" });
 		return;
 	}
-	const loginUserResult = await userService.loginUser(body.did, body.password);
-	if (!loginUserResult.ok) {
-		res.status(400).send({err: loginUserResult.val});
+	if (body.password == undefined) {
+		console.log("[-] WalletLogin: Missing password");
+		res.status(401).send({ err: "MISSING_PASSWORD" });
 		return;
+	}
+
+	const loginUserResult = await userService.loginUser(body.username, body.password);
+	if (!loginUserResult.ok) {
+		if(loginUserResult.val === "NOT_FOUND") {
+			console.log("[-] WalletLogin: Invalid credentials");
+			res.status(401).send({ err: "INVALID_CREDENTIALS" });
+			return;
+		}
+		else {
+			res.status(400).send({err: loginUserResult.val});
+			return;
+		}
 	}
 	const { appToken } = loginUserResult.val;
 

--- a/src/dto/user.dto.ts
+++ b/src/dto/user.dto.ts
@@ -4,7 +4,9 @@ import { FetchUserErrors, RegisterUserErrors } from "../types/errors/user.errors
 
 // Register User
 export type RegisterRequestDTO = {
+	username: string;
 	password: string;
+	repeatpw: string;
 }
 
 // what is the response our controller will return
@@ -17,7 +19,7 @@ export type RegisterResponseDTO = {
 // Login User
 
 export type LoginUserRequestDTO = {
-	did: string;
+	username: string;
 	password: string;
 }
 

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -5,6 +5,9 @@ export class User {
   @PrimaryGeneratedColumn()
   id: number = -1;
 
+	@Column({ unique: true, nullable: false})
+	username: string = "";
+
 	@Column({ unique: true, nullable: false })
 	did: string = "";
 

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -14,10 +14,12 @@ class UserRepository {
 	}
 
 	async createUser(
+		username: string,
 		did: string,
 		passwordHash: string): Promise<Result<null, "ALREADY_EXISTS">> {
 
 		const user = {
+			username: username,
 			did: did,
 			passwordHash: passwordHash,
 		};
@@ -51,13 +53,13 @@ class UserRepository {
 		}
 	}
 
-	async getUserByHash(
-		did: string,
+	async getUserByUsernameAndHash(
+		username: string,
 		passwordHash: string
 	): Promise<Result<User, FetchUserErrors>> {
 
 		try {
-			const user = await this.repo.findOne({where: {did: did, passwordHash: passwordHash}});
+			const user = await this.repo.findOne({where: {username: username, passwordHash: passwordHash}});
 			if (user == null)
 				return Err("NOT_FOUND");
 			return Ok(user);
@@ -80,6 +82,21 @@ class UserRepository {
 			if (user == null)
 				return Err("NOT_FOUND")
 			return Ok(user);
+		}
+		catch(e) {
+			console.log(e);
+			return Err("DB_ERROR");
+		}
+	}
+
+	async userExists(
+		username: string,
+	): Promise<Result<boolean, "DB_ERROR">> {
+		try {
+			const user = await this.repo.findOne({where: {username: username}});
+			if (user == null)
+				return Ok(false);
+			return Ok(true);
 		}
 		catch(e) {
 			console.log(e);

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -10,12 +10,13 @@ class UserService {
 	constructor() { }
 
 	/**
-	 * 
+	 * @param username
 	 * @param password
 	 * @returns
 	 * On success, returns the DID of the user.
 	 */
 	async registerUser(
+		username: string,
 		password: string
 	): Promise<Result<{did: string, appToken: string}, RegisterUserErrors>> {
 
@@ -41,7 +42,7 @@ class UserService {
 		// Step 2. Store user(did, passwordHash) on database
 		const { did } = generateDDIDResponse.data as { did: string };
 		const passwordHash = crypto.createHash('sha256').update(password).digest('base64');
-		const result = await userRepository.createUser(did, passwordHash);
+		const result = await userRepository.createUser(username, did, passwordHash);
 
 
 		// Step 3. Issue an app token for user authentication with StoreNodes and the SignatoryNode
@@ -61,17 +62,24 @@ class UserService {
 			return Err(result.val);
 	}
 
+	/**
+	 * @param username
+	 * @param password
+	 * @returns
+	 * On success, returns an authorized apptoken of the user.
+	 */
 	async loginUser(
-		did: string,
+		username: string,
 		password: string
 	): Promise<Result<{appToken: string}, FetchUserErrors>> {
 		
 		const passwordInputHash = crypto.createHash('sha256').update(password).digest('base64');
-		const userResult = await userRepository.getUserByHash(did, passwordInputHash);
+		const userResult = await userRepository.getUserByUsernameAndHash(username, passwordInputHash);
 
 		if (!userResult.ok) {
 			return Err(userResult.val);
 		}
+		const did: string = userResult.val.did;
 		const secret = new TextEncoder().encode(config.appSecret);
 		const appToken = await new SignJWT({did: did})
 			.setProtectedHeader({ alg: 'HS256' })
@@ -80,6 +88,23 @@ class UserService {
 			.setExpirationTime(config.appTokenExpiration)
 			.sign(secret);
 		return Ok({ appToken });
+	}
+
+	/**
+	 * @param username
+	 * @returns
+	 * Returns true if a user with the given username exists
+	 */
+	 async checkIfUserExists(
+		username: string,
+	): Promise<Result<boolean, "DB_ERROR">> {
+		
+		const userExistsRes = await userRepository.userExists(username);
+
+		if(userExistsRes.ok)
+			return Ok(userExistsRes.val);
+		else
+			return Err(userExistsRes.val);
 	}
 }
 


### PR DESCRIPTION
Identify users with a username-password combination instead of relying solely on their DID.

This allows users to use their existing wallet without an intricate wallet import/export mechanism, simply by memorizing their username-password combination.