### PR TITLE
Change upload-pages-artifact version

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v1
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # 👇 Specify build output path
           path: build


### PR DESCRIPTION
Change `upload-pages-artifact` to v3 which uses `upload-artifact` v4 to fix:
```
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```